### PR TITLE
Return to current directory to prevent error with symfony task

### DIFF
--- a/Drupal/Drupal.php
+++ b/Drupal/Drupal.php
@@ -125,6 +125,7 @@ final class Drupal implements DrupalInterface
         drush_set_option('root', $this->root);
 
         // make sure the default path point to the correct instance
+        $currentDirectory = getcwd();
         chdir($this->root);
 
         $phases = _drush_bootstrap_phases(FALSE, TRUE);
@@ -139,6 +140,8 @@ final class Drupal implements DrupalInterface
         foreach ($phases as $phase) {
             drush_bootstrap_to_phase($phase);
         }
+
+        chdir($currentDirectory);
     }
 
     /**


### PR DESCRIPTION
An issue was found when using the command assets:install. 
When used with relative path, the command may fail depending the path from where it is executed.
