### PR TITLE
EKINO_DRUSH_FROM already exists

### DIFF
--- a/EkinoDrupalBundle.php
+++ b/EkinoDrupalBundle.php
@@ -24,7 +24,7 @@ class EkinoDrupalBundle extends Bundle
     */
     public function boot()
     {
-        if (php_sapi_name() === 'cli') {
+        if (php_sapi_name() === 'cli' && !defined('EKINO_DRUSH_FROM')) {
 
             global $container;
 


### PR DESCRIPTION
When executed app/console cache:clear an exception is thrown because EKINO_DRUSH_FROM already exists.
