### PR TITLE
Prevent a double rendering of the output

### DIFF
--- a/Drupal/Drupal.php
+++ b/Drupal/Drupal.php
@@ -378,6 +378,7 @@ final class Drupal implements DrupalInterface
         $this->status = MENU_FOUND;
     }
 
+
     /**
      * Decorate the inner content and render the page
      *
@@ -400,10 +401,9 @@ final class Drupal implements DrupalInterface
             $defaultDeliveryCallback = $routerItem ? $routerItem['delivery_callback'] : NULL;
 
             $pageResultCallback = $drupal->getPageResultCallback();
-            ob_clean();
+
             drupal_deliver_page($pageResultCallback, $defaultDeliveryCallback);
             $drupal->setPageResultCallback($pageResultCallback);
-            return ob_get_clean();
         }, $this);
 
         $this->response->setContent($content);


### PR DESCRIPTION
In some cases, we realized that the output was rendered twice. For instance, this bug prevented the ajax system of the Drupal backend to work properly. 
