### PR TITLE
Adding exception listner for render 404 drupal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+composer.lock
+vendor

--- a/Entity/FosUser.php
+++ b/Entity/FosUser.php
@@ -17,9 +17,6 @@ use FOS\UserBundle\Model\UserInterface as FOSUserInterface;
 
 abstract class FosUser extends DrupalUser implements SecurityUserInterface, FOSUserInterface
 {
-    const ROLE_DEFAULT = 'ROLE_USER';
-    const ROLE_SUPER_ADMIN = 'ROLE_SUPER_ADMIN';
-
     /**
      * @var string
      */

--- a/Listener/ExceptionListener.php
+++ b/Listener/ExceptionListener.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Ekino\Bundle\DrupalBundle\Listener;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+use Ekino\Bundle\DrupalBundle\Drupal\DrupalInterface;
+use Ekino\Bundle\DrupalBundle\Drupal\InvalidStateMethodCallException;
+
+/**
+ * When Symfony throw a not found http exception, it response a drupal not found.
+ *
+ * @author Florent Denis <fdenis@ekino.com>
+ */
+class ExceptionListener
+{
+    /**
+     * @var DrupalInterface
+     */
+    protected $drupal;
+
+    /**
+     * Constructor.
+     *
+     * @param DrupalInterface $drupal
+     */
+    public function __construct(DrupalInterface $drupal)
+    {
+        $this->drupal = $drupal;
+    }
+
+    /**
+     * @param GetResponseForExceptionEvent $event
+     */
+    public function onKernelException(GetResponseForExceptionEvent $event)
+    {
+        $is404 = false;
+
+        try {
+            $is404 = $this->drupal->is404();
+        }
+        catch (InvalidStateMethodCallException $e) {}
+
+        if (!$is404) {
+            return;
+        }
+
+        $exception = $event->getException();
+
+        if ($exception instanceof NotFoundHttpException) {
+            $this->drupalRender();
+
+            $event->setResponse($this->drupal->getResponse());
+        }
+    }
+
+    /**
+     * Render drupal.
+     */
+    protected function drupalRender()
+    {
+        if ($this->drupal->isFound()) {
+            $this->drupal->buildContent();
+        }
+
+        $this->drupal->render();
+    }
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -7,6 +7,7 @@
     <parameters>
         <parameter key="session.class">Ekino\Bundle\DrupalBundle\Port\DrupalSession</parameter>
         <parameter key="ekino.drupal.drupal.class">Ekino\Bundle\DrupalBundle\Drupal\Drupal</parameter>
+        <parameter key="ekino.drupal.exception_listener.class">Ekino\Bundle\DrupalBundle\Listener\ExceptionListener</parameter>
     </parameters>
 
     <services>
@@ -32,6 +33,12 @@
 
         <service id="ekino.drupal.subscriber.user.orm" class="Ekino\Bundle\DrupalBundle\Event\Subscriber\UserSubscriber">
             <tag name="doctrine.event_subscriber" />
+        </service>
+
+        <service id="ekino.drupal.exception_listener" class="%ekino.drupal.exception_listener.class%">
+            <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" priority="-127" />
+
+            <argument type="service" id="ekino.drupal" />
         </service>
 
         <service id="ekino.drupal.subscriber.user.orm" class="Ekino\Bundle\DrupalBundle\Event\Subscriber\UserSubscriber">

--- a/Tests/Entity/UserTest.php
+++ b/Tests/Entity/UserTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Ekino\Bundle\DrupalBundle\Tests\Drupal;
+namespace Ekino\Bundle\DrupalBundle\Tests\Entity;
 
 use \Ekino\Bundle\DrupalBundle\Entity\User;
 
@@ -118,6 +118,7 @@ class UserTest extends \PHPUnit_Framework_TestCase
             'picture' => NULL,
             'init' => NULL,
             'data' => NULL,
+            'path' => NULL
         );
 
         $this->assertEquals($expected, unserialize($user->serialize()));

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,9 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "friendsofsymfony/user-bundle": "*"
+        "friendsofsymfony/user-bundle": "*",
+        "symfony/http-foundation": "*",
+        "symfony/http-kernel": "*"
     },
     "autoload": {
         "psr-0": { "Ekino\\Bundle\\DrupalBundle": "" }


### PR DESCRIPTION
When symfony throw a not found http exception, the exception listener set the response with the 404 drupal response.

I fix unit test too.
