### PR TITLE
Add a session.refresh_cookie_lifetime config parameter

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -59,6 +59,12 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
+                ->arrayNode('session')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->booleanNode('refresh_cookie_lifetime')->defaultFalse()->end()
+                    ->end()
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/EkinoDrupalExtension.php
+++ b/DependencyInjection/EkinoDrupalExtension.php
@@ -54,6 +54,9 @@ class EkinoDrupalExtension extends Extension
             ->replaceArgument(2, $config['provider_keys']);
 
         $container->setAlias('logger', $config['logger']);
+
+        $container->getDefinition('ekino.drupal.session.storage')
+            ->replaceArgument(1, $config['session']['refresh_cookie_lifetime']);
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Drupal Bundle by Ekino
 ======================
 
+[![Build Status](https://secure.travis-ci.org/ekino/EkinoDrupalBundle.png?branch=master)](http://travis-ci.org/ekino/EkinoDrupalBundle)
+
 **Requires** at least *Drush 5.0* for compatibility with Symfony console.
 
 The bundle tries to deeply integrate Symfony2 with Drupal and Drupal with Symfony2. Of course this is done without
@@ -88,6 +90,10 @@ Edit the Symfony ``config.yml`` file and add the following lines:
             enabled: false
             prefix:  symfony__
             exclude: [users]
+
+        # optional
+        session:
+            refresh_cookie_lifetime: true # default value: false
 
     # declare 2 required mapping definition used by Drupal
     doctrine:

--- a/Resources/config/session.xml
+++ b/Resources/config/session.xml
@@ -13,6 +13,7 @@
     <services>
         <service id="ekino.drupal.session.storage" class="%ekino.drupal.session.storage.class%">
             <argument type="service" id="ekino.drupal" />
+            <argument />
         </service>
     </services>
 </container>

--- a/Tests/Port/DrupalSessionStorageTest.php
+++ b/Tests/Port/DrupalSessionStorageTest.php
@@ -1,0 +1,133 @@
+<?php
+
+/*
+ * This file is part of the Ekino Drupal package.
+ *
+ * (c) 2011 Ekino
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace {
+    $started = false;
+    $time = 0;
+}
+
+/**
+ * Mock Drupal function calls
+ */
+namespace Ekino\Bundle\DrupalBundle\Port {
+    /**
+     * Mock call to Drupal drupal_session_started() function
+     *
+     * @return bool
+     */
+    function drupal_session_started()
+    {
+        global $started;
+
+        return $started;
+    }
+
+    /**
+     * Mock call to Drupal drupal_session_start() function
+     *
+     * @return void
+     */
+    function drupal_session_start()
+    {
+        global $time;
+
+        $time += 1;
+    }
+
+    /**
+     * Mock PHP built-in setcookie() function
+     *
+     * @param $name
+     * @param $value
+     * @param $expire
+     * @param $path
+     * @param $domain
+     * @param $secure
+     * @param $httponly
+     */
+    function setcookie($name, $value, $expire, $path, $domain, $secure, $httponly)
+    {
+        global $time;
+
+        $time += 1;
+    }
+}
+
+namespace Ekino\Bundle\DrupalBundle\Tests\Port {
+
+    use Ekino\Bundle\DrupalBundle\Port\DrupalSessionStorage;
+
+    /**
+     * Tests the Drupal session storage
+     *
+     * @author Vincent Composieux <vincent.composieux@gmail.com>
+     */
+    class DrupalSessionStorageTest extends \PHPUnit_Framework_TestCase
+    {
+        /**
+         * Tests Drupal session storage service
+         */
+        public function testSessionStorage()
+        {
+            // Given
+            global $time;
+
+            $session = $this->getDrupalSessionStorageMock(false);
+
+            // When
+            $session->start();
+
+            // Then
+            $this->assertEquals(1, $time, 'Time should be equal to 1 because 1 iteration is done');
+        }
+
+        /**
+         * Tests Drupal session storage service with cookie session refresh lifetime
+         */
+        public function testSessionStorageWithRefreshLifetime()
+        {
+            // Given
+            global $started, $time;
+
+            $session = $this->getDrupalSessionStorageMock(true);
+
+            $started = true;
+
+            // When
+            $session->start();
+
+            // Then
+            $this->assertEquals(2, $time, 'Time should be equal to 2 because 2 iteration is done');
+        }
+
+        /**
+         * Returns DrupalSessionStorage mock
+         *
+         * @param bool $refreshCookieLifetime
+         *
+         * @return DrupalSessionStorage
+         */
+        protected function getDrupalSessionStorageMock($refreshCookieLifetime)
+        {
+            $drupal = $this->getMockBuilder('Ekino\Bundle\DrupalBundle\Drupal\Drupal')
+                ->disableOriginalConstructor()
+                ->getMock();
+
+            $bag = $this->getMock('Symfony\Component\HttpFoundation\Session\SessionBagInterface');
+            $bag->expects($this->any())->method('getName')->will($this->returnValue('test'));
+
+            $session = new DrupalSessionStorage($drupal, $refreshCookieLifetime);
+            $session->registerBag($bag);
+
+            return $session;
+        }
+    }
+}


### PR DESCRIPTION
#### Use case

When using `DrupalSessionStorage`, the PHP `session.cookie_lifetime` parameter is well-used for calculating the session duration.

Problem is when we want the user to be disconnected after X seconds only when he is inactive.

Drupal doesn't have this feature so I've added it in this bundle.
#### How it works

I've added the following bundle configuration parameter:

``` yml
ekino_drupal:
    session:
        refresh_cookie_lifetime: true # default value: false
```

When enabled (true), cookie lifetime will be updated with the current request time.
This is disabled by default and user can enable it when it needs.
