### PR TITLE
Add Twig ToolbarExtension to render administration toolbar

### DIFF
--- a/DependencyInjection/EkinoDrupalExtension.php
+++ b/DependencyInjection/EkinoDrupalExtension.php
@@ -40,6 +40,7 @@ class EkinoDrupalExtension extends Extension
         $loader->load('services.xml');
         $loader->load('session.xml');
         $loader->load('user_hook.xml');
+        $loader->load('twig.xml');
 
         $this->configureEntityRepositories($container, $config);
         $this->configureTablesPrefix($container, $config);

--- a/Resources/config/twig.xml
+++ b/Resources/config/twig.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="ekino_drupal.twig.toolbar_extension" class="Ekino\Bundle\DrupalBundle\Twig\ToolbarExtension">
+            <tag name="twig.extension" />
+        </service>
+    </services>
+</container>

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -1,0 +1,14 @@
+Ekino Drupal Bundle
+===================
+
+The ``EkinoDrupalBundle`` tries to deeply integrate Symfony2 with Drupal and Drupal with Symfony2. Of course this is done without
+altering the Drupal's core.
+
+Reference Guide
+---------------
+
+.. toctree::
+:maxdepth: 1
+       :numbered:
+
+       reference/twig

--- a/Resources/doc/reference/twig.rst
+++ b/Resources/doc/reference/twig.rst
@@ -1,0 +1,34 @@
+.. index::
+single: Extensions Twig
+
+Extensions Twig
+===============
+
+We provide a Twig extension to help rendering Drupal parts into your Symfony Twig templates.
+
+ToolbarExtension
+----------------
+
+You can render the administration Drupal toolbar parts by adding the following HTML to your Twig template:
+
+.. code-block:: html
+
+    {% if is_granted('PERMISSION_DRUPAL_ACCESS_TOOLBAR') %}
+        <div id="toolbar" class="toolbar overlay-displace-top clearfix toolbar-processed">
+            <div class="toolbar-menu clearfix">
+                {{ ekino_drupal_toolbar_render_item('toolbar_home') }}
+                {{ ekino_drupal_toolbar_render_item('toolbar_user') }}
+                {{ ekino_drupal_toolbar_render_item('toolbar_menu') }}
+                {{ ekino_drupal_toolbar_render_item('toolbar_toggle') }}
+            </div>
+        </div>
+    {% endif %}
+
+Please ensure that your user has the correct role to "access toolbar" in Drupal administration.
+
+As an additional note, you will also need to load the following stylesheets:
+
+.. code-block:: html
+
+    <link rel="stylesheet" type="text/css" href="{{ asset('modules/system/system.base.css') }}" />
+    <link rel="stylesheet" type="text/css" href="{{ asset('modules/toolbar/toolbar.css') }}" />

--- a/Tests/Twig/ToolbarExtensionTest.php
+++ b/Tests/Twig/ToolbarExtensionTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of the Ekino Drupal package.
+ *
+ * (c) 2011 Ekino
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace {
+    /**
+     * Fake Drupal toolbar_view() function
+     *
+     * @return array
+     */
+    function toolbar_view()
+    {
+        return array('test' => 'value');
+    }
+
+    /**
+     * Fake Drupal render() function
+     *
+     * @param string $item
+     *
+     * @return string
+     */
+    function render($item)
+    {
+        return sprintf('<h1>%s</h1>', $item);
+    }
+}
+
+namespace Ekino\Bundle\DrupalBundle\Tests\Twig {
+    use Ekino\Bundle\DrupalBundle\Twig\ToolbarExtension;
+
+    /**
+     * Class ToolbarExtensionTest
+     *
+     * @author Vincent Composieux <vincent.composieux@gmail.com>
+     */
+    class ToolbarExtensionTest extends \PHPUnit_Framework_TestCase
+    {
+        /**
+         * @var ToolbarExtension
+         */
+        protected $extension;
+
+        /**
+         * Sets up Twig toolbar extension
+         */
+        public function setUp()
+        {
+            $this->extension = new ToolbarExtension();
+        }
+
+        /**
+         * Tests the getFunctions() method
+         */
+        public function testGetFunctions()
+        {
+            $functions = $this->extension->getFunctions();
+
+            $this->assertTrue(is_array($functions), 'Should return an array of functions');
+
+            foreach ($functions as $function) {
+                $this->assertInstanceOf('\Twig_SimpleFunction', $function);
+            }
+        }
+
+        /**
+         * Tests the renderToolbarItem() method
+         */
+        public function testRenderToolbarItem()
+        {
+            // When
+            $result = $this->extension->renderToolbarItem('test');
+
+            // Then
+            $this->assertEquals('<h1>value</h1>', $result, 'Should return render() function');
+        }
+
+        /**
+         * Tests the getName() method
+         */
+        public function testGetName()
+        {
+            // When
+            $name = $this->extension->getName();
+
+            // Then
+            $this->assertEquals('ekino_drupal_toolbar_extension', $name, 'Should return correct Twig extension name');
+        }
+    }
+}

--- a/Twig/ToolbarExtension.php
+++ b/Twig/ToolbarExtension.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Ekino Drupal package.
+ *
+ * (c) 2011 Ekino
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ekino\Bundle\DrupalBundle\Twig;
+
+/**
+ * Twig toolbar extension class
+ *
+ * @author Vincent Composieux <vincent.composieux@gmail.com>
+ */
+class ToolbarExtension extends \Twig_Extension
+{
+    /**
+     * @var array
+     */
+    protected $toolbar;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions()
+    {
+        return array(
+            new \Twig_SimpleFunction('ekino_drupal_toolbar_render_item', array($this, 'renderToolbarItem'), array(
+                'is_safe' => array('html')
+            )),
+        );
+    }
+
+    /**
+     * Renders HTML for a Drupal administration toolbar item
+     *
+     * @param $item
+     *
+     * @return string
+     */
+    public function renderToolbarItem($item)
+    {
+        if (null === $this->toolbar) {
+            $this->toolbar = toolbar_view();
+        }
+
+        return render($this->toolbar[$item]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'ekino_drupal_toolbar_extension';
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "php": ">=5.3.2",
         "friendsofsymfony/user-bundle": "*",
         "symfony/http-foundation": ">=2.1,<3.0-dev",
-        "symfony/http-kernel": ">=2.1,<3.0-dev"
+        "symfony/http-kernel": ">=2.1,<3.0-dev",
+        "twig/extensions": "1.0.*"
     },
     "autoload": {
         "psr-0": { "Ekino\\Bundle\\DrupalBundle": "" }


### PR DESCRIPTION
This Twig extension will allow to render parts of Drupal administration toolbar into a Symfony Twig template.

Here is the toolbar rendered:

![capture decran 2014-05-28 a 11 27 03](https://cloud.githubusercontent.com/assets/103900/3102687/5ecb0cb8-e64a-11e3-884c-bb2a43b16762.png)
