### PR TITLE
Fix EntityRepository findOnePublishedBy() method for status overriding

### DIFF
--- a/Entity/EntityRepository.php
+++ b/Entity/EntityRepository.php
@@ -160,10 +160,14 @@ class EntityRepository
      */
     public function findOnePublishedBy(array $entityConditions, array $propertyConditions = array(), array $fieldConditions = array())
     {
-        $propertyConditions = array_replace_recursive($propertyConditions, array(array(
+        $propertyConditions = array_filter($propertyConditions, function ($item) {
+            return isset($item['column']) && 'status' != $item['column'];
+        });
+
+        $propertyConditions[] = array(
             'column' => 'status',
             'value'  => 1,
-        )));
+        );
 
         return $this->findOneBy($entityConditions, $propertyConditions, $fieldConditions);
     }

--- a/Tests/Entity/EntityRepositoryTest.php
+++ b/Tests/Entity/EntityRepositoryTest.php
@@ -310,13 +310,45 @@ class EntityRepositoryTest extends \PHPUnit_Framework_TestCase
         $repository
             ->expects($this->once())
             ->method('findOneBy')
-            ->with($this->equalTo($criteria), $this->equalTo(array(array(
-                'column' => 'status',
-                'value'  => 1,
-            ))))
+            ->with($this->equalTo($criteria), $this->equalTo(array(
+                array('column' => 'language', 'value'  => 'fr'),
+                array('column' => 'status',   'value'  => 1),
+            )))
             ->will($this->returnValue(array()));
 
-        $repository->findOnePublishedBy($criteria);
+        $repository->findOnePublishedBy($criteria, array(
+            array('column' => 'language', 'value' => 'fr')
+        ));
+    }
+
+    /**
+     * Tests the findOnePublishedBy method when trying to override status
+     */
+    public function testFindOnePublishedByTryingToOverrideStatus()
+    {
+        $repository = $this->getMockBuilder('Ekino\Bundle\DrupalBundle\Entity\EntityRepository')
+            ->setConstructorArgs(array('node'))
+            ->setMethods(array('findOneBy'))
+            ->getMock();
+
+        $criteria = array(
+            array('name' => 'entity_type', 'value' => 'node'),
+            array('name' => 'bundle',      'value' => 'page'),
+        );
+
+        $repository
+            ->expects($this->once())
+            ->method('findOneBy')
+            ->with($this->equalTo($criteria), $this->equalTo(array(
+                array('column' => 'language', 'value'  => 'fr'),
+                array('column' => 'status',   'value'  => 1),
+            )))
+            ->will($this->returnValue(array()));
+
+        $repository->findOnePublishedBy($criteria, array(
+            array('column' => 'language', 'value' => 'fr'),
+            array('column' => 'status', 'value' => 0)
+        ));
     }
 
     /**


### PR DESCRIPTION
When using method `EntityRepository::findOnePublishedBy()`, status is forced to 1 (published).

The issue is that actually, we cannot pass any other property condition as `array_replace_recursive()` function will replace it with the `status` column.

I've fixed this by using an `array_filter()` that checks if a status is sent and override it with correct value in this case. Otherwise, published status is added to every query.
