### PR TITLE
Added a BackgroundDeliveryStrategy in order to never render Drupal

### DIFF
--- a/Delivery/BackgroundDeliveryStrategy.php
+++ b/Delivery/BackgroundDeliveryStrategy.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Ekino Drupal package.
+ *
+ * (c) 2011 Ekino
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ekino\Bundle\DrupalBundle\Delivery;
+
+use Ekino\Bundle\DrupalBundle\Drupal\DrupalInterface;
+
+/**
+ * This strategy is used to let Symfony drive all the frontend and use Drupal in background.
+ *
+ * @author Vincent Composieux <vincent.composieux@gmail.com>
+ */
+class BackgroundDeliveryStrategy implements DeliveryStrategyInterface
+{
+    /**
+     * @param DrupalInterface $drupal
+     */
+    public function buildResponse(DrupalInterface $drupal)
+    {
+        $drupal->disableResponse();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -116,10 +116,11 @@ Edit the Symfony ``config.yml`` file and add the following lines:
             # the doctrine_migrations section (table_name)
             schema_filter: ~^(symfony__|migration_versions)~
 
-The bundle comes with 2 delivery strategies:
+The bundle comes with 3 delivery strategies:
 
+* ekino.drupal.delivery_strategy.background: Drupal never returns the response, Symfony does
+* ekino.drupal.delivery_strategy.drupal: Drupal always returns the response, even if the page is 404
 * ekino.drupal.delivery_strategy.symfony: Drupal returns the response only if the page is not 404
-* ekino.drupal.delivery_strategy.drupal : Drupal always returns the response, even if the page is 404
 
 The (optional) section ``entity_repositories`` allows you to easy interact with
 Drupal API to retrieve contents and handle it from Symfony code.

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -23,6 +23,8 @@
             <argument />
         </service>
 
+        <service id="ekino.drupal.delivery_strategy.background" class="Ekino\Bundle\DrupalBundle\Delivery\BackgroundDeliveryStrategy" />
+
         <service id="ekino.drupal.delivery_strategy.drupal" class="Ekino\Bundle\DrupalBundle\Delivery\FullDrupalDeliveryStrategy" />
 
         <service id="ekino.drupal.delivery_strategy.symfony" class="Ekino\Bundle\DrupalBundle\Delivery\FullSymfonyDeliveryStrategy" />

--- a/Tests/Delivery/BackgroundDeliveryStrategyTest.php
+++ b/Tests/Delivery/BackgroundDeliveryStrategyTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Ekino Drupal package.
+ *
+ * (c) 2011 Ekino
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ekino\Bundle\DrupalBundle\Tests\Delivery;
+
+use Ekino\Bundle\DrupalBundle\Delivery\BackgroundDeliveryStrategy;
+
+/**
+ * Tests the background delivery strategy class.
+ *
+ * @author Vincent Composieux <vincent.composieux@gmail.com>
+ */
+class BackgroundDeliveryStrategyTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Tests the buildResponse() method.
+     *
+     * The disableContent() method on the Drupal instance should be called in any case.
+     */
+    public function testIsFound()
+    {
+        $drupal = $this->getMock('Ekino\Bundle\DrupalBundle\Drupal\DrupalInterface');
+        $drupal->expects($this->once())->method('disableResponse');
+
+        $strategy = new BackgroundDeliveryStrategy();
+        $strategy->buildResponse($drupal);
+    }
+}


### PR DESCRIPTION
I've added a new `BackgroundDeliveryStrategy` in order to always let Symfony drive all the frontend. Because sometime, we only need to use Drupal in the background.