### PR TITLE
Fixed Drupal buffer rendering

### DIFF
--- a/Drupal/Drupal.php
+++ b/Drupal/Drupal.php
@@ -508,7 +508,6 @@ class Drupal implements DrupalInterface
         }
 
         ob_end_flush();
-        ob_clean();
 
         $headers = $this->cleanHeaders();
 


### PR DESCRIPTION
I was working on some Drupal ajax calls failing due to output buffering into `EkinoDrupalBundle`.

Indeed, it is actually using (in order):

* `ob_end_flush()`: Flush (send) the output buffer and turn off output buffering [...] buffer contents are discarded after ob_end_flush() is called,
* `ob_clean()`: Clean (erase) the output buffer.

I've removed the `ob_clean()` call as the issue here is that `ob_end_flush()` also erase the buffer so the `ob_clean()` call just after is rendering the following notice:

```
Notice: ob_clean(): failed to delete buffer. No buffer to delete in /in/4unkP on line 6
```

Here is a reproduction of this bug: https://3v4l.org/4unkP