### PR TITLE
Added missing kernel.terminate on index.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,12 @@ global $container;
 
 $container = $kernel->getContainer();
 
-$kernel->handle(Request::createFromGlobals())->send();
+$request = Request::createFromGlobals();
+
+$response = $kernel->handle($request);
+$response->send();
+
+$kernel->terminate($request, $response);
 ```
 ### Install the related Drupal module
 


### PR DESCRIPTION
The availability to trigger the Symfony `kernel.terminate` event was missing into the current documentation of `index.php` file code.